### PR TITLE
Port default chicken data and configuration

### DIFF
--- a/SUGGESTIONS.md
+++ b/SUGGESTIONS.md
@@ -1,0 +1,6 @@
+# Suggestions
+
+- Flesh out the placeholder registry scaffolding by porting entity, block, GUI, and integration classes from the legacy project using the new NeoForge data-driven patterns.
+- Migrate runtime recipes and loot tables from script-based registration to JSON data packs compatible with 1.21.1.
+- Replace the temporary debug item with the real Chickens content and add automated tests (e.g., data generators or unit tests) to guard the future porting work.
+- Restore the bespoke behaviours for the analyzer, spawn egg, colored egg, and liquid egg items so the placeholders regain their legacy functionality.

--- a/TRACELOG.md
+++ b/TRACELOG.md
@@ -1,0 +1,20 @@
+# Trace Log
+
+## Entry 1
+- **Prompt/Task**: Port the OriginalChickens mod to NeoForge 1.21.1 and begin the ModernChickens project.
+- **Steps**:
+  1. Created a dedicated NeoForge Gradle project with wrapper configuration and metadata tailored for the Modern Chickens mod.
+  2. Reused the legacy resource bundle by wiring the original assets directory into the new source set to avoid duplicating binaries.
+  3. Implemented foundational registry/data classes (`ChickensRegistry`, `ChickensRegistryItem`, `SpawnType`) updated to modern APIs and tagging systems.
+  4. Added an initial mod entry point and registry bootstrap that compiles against NeoForge 1.21.1, including a placeholder item for smoke testing.
+  5. Resolved build-time dependency gaps and executed a full `gradle build` to confirm the scaffolding compiles successfully.
+- **Rationale**: Establishing a clean buildable skeleton ensures future ports of entities, blocks, GUIs, and gameplay logic can iterate safely on top of a verified NeoForge 1.21.1 foundation.
+
+## Entry 2
+- **Prompt/Task**: Continue porting OriginalChickens functionality by loading the legacy chicken roster and configuration into the NeoForge project.
+- **Steps**:
+  1. Added configuration support with `ChickensDataLoader`, carrying over the original per-chicken tuning controls via a modernised properties file and updating the runtime config holder.
+  2. Recreated the legacy chicken catalogue in `DefaultChickens`, adapting item and block references to 1.21.1 resources while wiring in placeholder liquid egg items.
+  3. Registered stubbed versions of the analyzer, spawn egg, colored egg, and liquid egg items plus the liquid egg registry data so downstream systems have concrete identifiers to bind against.
+  4. Hooked the common setup event to bootstrap the data pipeline and verified the resulting build with `gradle --no-daemon --console=plain build`.
+- **Rationale**: Loading the full chicken definitions early allows subsequent ports (entities, rendering, GUIs) to rely on accurate data parity, while the configuration bridge keeps existing worlds and packs customisable during the migration.

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,55 @@
+plugins {
+    id 'net.neoforged.moddev' version '1.0.11'
+    id 'maven-publish'
+}
+
+version = '1.0.0'
+group = 'com.setycz.chickens'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+repositories {
+    mavenCentral()
+    maven { url = 'https://maven.neoforged.net/releases' }
+}
+
+sourceSets {
+    main {
+        resources {
+            // Reuse the original assets to avoid duplicating large binary files.
+            srcDir 'OriginalChickens/src/main/resources'
+        }
+    }
+}
+
+dependencies {
+    // Explicitly depend on NeoForge's API to make IDE and compilation happy.
+    implementation "net.neoforged:neoforge:${project.neoforge_version}"
+}
+
+neoForge {
+    version = project.neoforge_version
+    addModdingDependenciesTo(sourceSets.main)
+    runs {
+        client { client() }
+        server { server() }
+        data { data() }
+    }
+    mods {
+        modernchickens {
+            sourceSet sourceSets.main
+        }
+    }
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+org.gradle.configuration-cache=true
+org.gradle.jvmargs=-Xmx3G
+
+minecraft_version=1.21.1
+neoforge_version=21.1.5

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'ModernChickens'

--- a/src/main/java/com/setycz/chickens/ChickensMod.java
+++ b/src/main/java/com/setycz/chickens/ChickensMod.java
@@ -1,0 +1,33 @@
+package com.setycz.chickens;
+
+import com.setycz.chickens.data.ChickensDataLoader;
+import com.setycz.chickens.registry.ModRegistry;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Entry point for the modernised Chickens mod. At this stage we bootstrap
+ * the NeoForge event listeners and leave placeholders for the extensive
+ * content port that will follow.
+ */
+@Mod(ChickensMod.MOD_ID)
+public final class ChickensMod {
+    public static final String MOD_ID = "chickens";
+    private static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
+
+    public ChickensMod(IEventBus modBus) {
+        ModRegistry.init(modBus);
+        modBus.addListener(this::onCommonSetup);
+        LOGGER.info("Modern Chickens mod initialised. Legacy content will be registered during later setup stages.");
+    }
+
+    public void onCommonSetup(FMLCommonSetupEvent event) {
+        LOGGER.info("Running common setup for Modern Chickens");
+        // Defer the heavy registry bootstrap so it runs on the correct thread
+        // once NeoForge has finished initialising its data tables.
+        event.enqueueWork(ChickensDataLoader::bootstrap);
+    }
+}

--- a/src/main/java/com/setycz/chickens/ChickensRegistry.java
+++ b/src/main/java/com/setycz/chickens/ChickensRegistry.java
@@ -1,0 +1,172 @@
+package com.setycz.chickens;
+
+import net.minecraft.core.Holder;
+import net.minecraft.world.level.biome.Biome;
+import net.neoforged.neoforge.common.Tags;
+
+import javax.annotation.Nullable;
+import java.util.*;
+
+/**
+ * Central registry that keeps track of every chicken descriptor. Mirrors
+ * the responsibilities of the legacy implementation but upgrades the
+ * biome logic to make use of modern tag helpers.
+ */
+public final class ChickensRegistry {
+    private static final Map<Integer, ChickensRegistryItem> ITEMS = new HashMap<>();
+    public static final int SMART_CHICKEN_ID = 50;
+    private static final Random RAND = new Random();
+
+    private ChickensRegistry() {
+    }
+
+    public static void register(ChickensRegistryItem entity) {
+        validate(entity);
+        ITEMS.put(entity.getId(), entity);
+    }
+
+    private static void validate(ChickensRegistryItem entity) {
+        for (ChickensRegistryItem item : ITEMS.values()) {
+            if (entity.getId() == item.getId()) {
+                throw new IllegalStateException("Duplicate chicken id " + entity.getId());
+            }
+            if (entity.getEntityName().equalsIgnoreCase(item.getEntityName())) {
+                throw new IllegalStateException("Duplicate chicken name " + entity.getEntityName());
+            }
+        }
+    }
+
+    public static ChickensRegistryItem getByType(int type) {
+        return ITEMS.get(type);
+    }
+
+    public static Collection<ChickensRegistryItem> getItems() {
+        List<ChickensRegistryItem> result = new ArrayList<>();
+        for (ChickensRegistryItem chicken : ITEMS.values()) {
+            if (chicken.isEnabled()) {
+                result.add(chicken);
+            }
+        }
+        return result;
+    }
+
+    public static Collection<ChickensRegistryItem> getDisabledItems() {
+        List<ChickensRegistryItem> result = new ArrayList<>();
+        for (ChickensRegistryItem chicken : ITEMS.values()) {
+            if (!chicken.isEnabled()) {
+                result.add(chicken);
+            }
+        }
+        return result;
+    }
+
+    private static List<ChickensRegistryItem> getChildren(ChickensRegistryItem parent1, ChickensRegistryItem parent2) {
+        List<ChickensRegistryItem> result = new ArrayList<>();
+        if (parent1.isEnabled()) {
+            result.add(parent1);
+        }
+        if (parent2.isEnabled()) {
+            result.add(parent2);
+        }
+        for (ChickensRegistryItem item : ITEMS.values()) {
+            if (item.isEnabled() && item.isChildOf(parent1, parent2)) {
+                result.add(item);
+            }
+        }
+        return result;
+    }
+
+    @Nullable
+    public static ChickensRegistryItem findDyeChicken(net.minecraft.world.item.crafting.Ingredient colour) {
+        for (ChickensRegistryItem chicken : ITEMS.values()) {
+            if (chicken.isDye(colour)) {
+                return chicken;
+            }
+        }
+        return null;
+    }
+
+    public static List<ChickensRegistryItem> getPossibleChickensToSpawn(SpawnType spawnType) {
+        List<ChickensRegistryItem> result = new ArrayList<>();
+        for (ChickensRegistryItem chicken : ITEMS.values()) {
+            if (chicken.canSpawn() && chicken.getSpawnType() == spawnType && chicken.isEnabled()) {
+                result.add(chicken);
+            }
+        }
+        return result;
+    }
+
+    public static SpawnType getSpawnType(Holder<Biome> biomeHolder) {
+        if (biomeHolder.is(Tags.Biomes.IS_NETHER)) {
+            return SpawnType.HELL;
+        }
+        if (biomeHolder.is(Tags.Biomes.IS_SNOWY)) {
+            return SpawnType.SNOW;
+        }
+        return SpawnType.NORMAL;
+    }
+
+    public static float getChildChance(ChickensRegistryItem child) {
+        if (child.getTier() <= 1) {
+            return 0;
+        }
+        List<ChickensRegistryItem> possibleChildren = getChildren(child.getParent1(), child.getParent2());
+        int maxChance = getMaxChance(possibleChildren);
+        int maxDiceValue = getMaxDiceValue(possibleChildren, maxChance);
+        return ((maxChance - child.getTier()) * 100.0f) / maxDiceValue;
+    }
+
+    @Nullable
+    public static ChickensRegistryItem getRandomChild(ChickensRegistryItem parent1, ChickensRegistryItem parent2) {
+        List<ChickensRegistryItem> possibleChildren = getChildren(parent1, parent2);
+        if (possibleChildren.isEmpty()) {
+            return null;
+        }
+        int maxChance = getMaxChance(possibleChildren);
+        int maxDiceValue = getMaxDiceValue(possibleChildren, maxChance);
+        int diceValue = RAND.nextInt(maxDiceValue);
+        return getChickenToBeBorn(possibleChildren, maxChance, diceValue);
+    }
+
+    @Nullable
+    private static ChickensRegistryItem getChickenToBeBorn(List<ChickensRegistryItem> possibleChildren, int maxChance, int diceValue) {
+        int currentValue = 0;
+        for (ChickensRegistryItem child : possibleChildren) {
+            currentValue += maxChance - child.getTier();
+            if (diceValue < currentValue) {
+                return child;
+            }
+        }
+        return null;
+    }
+
+    private static int getMaxDiceValue(List<ChickensRegistryItem> possibleChildren, int maxChance) {
+        int maxDiceValue = 0;
+        for (ChickensRegistryItem child : possibleChildren) {
+            maxDiceValue += maxChance - child.getTier();
+        }
+        return maxDiceValue;
+    }
+
+    private static int getMaxChance(List<ChickensRegistryItem> possibleChildren) {
+        int maxChance = 0;
+        for (ChickensRegistryItem child : possibleChildren) {
+            maxChance = Math.max(maxChance, child.getTier());
+        }
+        return maxChance + 1;
+    }
+
+    public static boolean isAnyIn(SpawnType spawnType) {
+        for (ChickensRegistryItem chicken : ITEMS.values()) {
+            if (chicken.canSpawn() && chicken.isEnabled() && chicken.getSpawnType() == spawnType) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Nullable
+    public static ChickensRegistryItem getSmartChicken() {
+        return ITEMS.get(SMART_CHICKEN_ID);
+    }
+}

--- a/src/main/java/com/setycz/chickens/ChickensRegistryItem.java
+++ b/src/main/java/com/setycz/chickens/ChickensRegistryItem.java
@@ -1,0 +1,168 @@
+package com.setycz.chickens;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.DyeItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+
+import javax.annotation.Nullable;
+
+/**
+ * Registry entry describing a single chicken type. Ported from the
+ * original 1.10 implementation with modern item helpers. Each instance
+ * stores breeding information, presentation data and the drop/lay
+ * behaviour that the entity class consumes at runtime.
+ */
+public class ChickensRegistryItem {
+    private final int id;
+    private final String entityName;
+    private ItemStack layItem;
+    private ItemStack dropItem;
+    private final int bgColor;
+    private final int fgColor;
+    private final ResourceLocation texture;
+    private ChickensRegistryItem parent1;
+    private ChickensRegistryItem parent2;
+    private SpawnType spawnType;
+    private boolean enabled = true;
+    private float layCoefficient = 1.0f;
+
+    public ChickensRegistryItem(int id, String entityName, ResourceLocation texture, ItemStack layItem, int bgColor, int fgColor) {
+        this(id, entityName, texture, layItem, bgColor, fgColor, null, null);
+    }
+
+    public ChickensRegistryItem(int id, String entityName, ResourceLocation texture, ItemStack layItem, int bgColor, int fgColor,
+            @Nullable ChickensRegistryItem parent1, @Nullable ChickensRegistryItem parent2) {
+        this.id = id;
+        this.entityName = entityName;
+        this.layItem = layItem.copy();
+        this.bgColor = bgColor;
+        this.fgColor = fgColor;
+        this.texture = texture;
+        this.spawnType = SpawnType.NORMAL;
+        this.parent1 = parent1;
+        this.parent2 = parent2;
+    }
+
+    public ChickensRegistryItem setDropItem(ItemStack stack) {
+        dropItem = stack.copy();
+        return this;
+    }
+
+    public ChickensRegistryItem setSpawnType(SpawnType type) {
+        spawnType = type;
+        return this;
+    }
+
+    public ChickensRegistryItem setLayCoefficient(float coefficient) {
+        layCoefficient = coefficient;
+        return this;
+    }
+
+    public String getEntityName() {
+        return entityName;
+    }
+
+    @Nullable
+    public ChickensRegistryItem getParent1() {
+        return parent1;
+    }
+
+    @Nullable
+    public ChickensRegistryItem getParent2() {
+        return parent2;
+    }
+
+    public int getBgColor() {
+        return bgColor;
+    }
+
+    public int getFgColor() {
+        return fgColor;
+    }
+
+    public ResourceLocation getTexture() {
+        return texture;
+    }
+
+    public ItemStack createLayItem() {
+        return layItem.copy();
+    }
+
+    public ItemStack createDropItem() {
+        if (dropItem != null) {
+            return dropItem.copy();
+        }
+        return createLayItem();
+    }
+
+    public int getTier() {
+        if (parent1 == null || parent2 == null) {
+            return 1;
+        }
+        return Math.max(parent1.getTier(), parent2.getTier()) + 1;
+    }
+
+    public boolean isChildOf(ChickensRegistryItem possibleParent1, ChickensRegistryItem possibleParent2) {
+        return parent1 == possibleParent1 && parent2 == possibleParent2 || parent1 == possibleParent2 && parent2 == possibleParent1;
+    }
+
+    public boolean isDye() {
+        return layItem.getItem() instanceof DyeItem;
+    }
+
+    public boolean isDye(Ingredient colour) {
+        return isDye() && colour.test(layItem);
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public boolean canSpawn() {
+        return getTier() == 1 && spawnType != SpawnType.NONE;
+    }
+
+    public int getMinLayTime() {
+        return (int) Math.max(6000 * getTier() * layCoefficient, 1.0f);
+    }
+
+    public int getMaxLayTime() {
+        return 2 * getMinLayTime();
+    }
+
+    public SpawnType getSpawnType() {
+        return spawnType;
+    }
+
+    public boolean isImmuneToFire() {
+        return spawnType == SpawnType.HELL;
+    }
+
+    public void setEnabled(boolean value) {
+        enabled = value;
+    }
+
+    public boolean isEnabled() {
+        return enabled && (parent1 == null || parent1.isEnabled()) && (parent2 == null || parent2.isEnabled());
+    }
+
+    public void setLayItem(ItemStack itemStack) {
+        layItem = itemStack.copy();
+    }
+
+    public void setNoParents() {
+        parent1 = null;
+        parent2 = null;
+    }
+
+    public ChickensRegistryItem setParentsNew(ChickensRegistryItem newParent1, ChickensRegistryItem newParent2) {
+        parent1 = newParent1;
+        parent2 = newParent2;
+        return this;
+    }
+
+    public boolean isBreedable() {
+        return parent1 != null && parent2 != null;
+    }
+}

--- a/src/main/java/com/setycz/chickens/LiquidEggRegistry.java
+++ b/src/main/java/com/setycz/chickens/LiquidEggRegistry.java
@@ -1,0 +1,30 @@
+package com.setycz.chickens;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Straightforward port of the legacy registry that keeps track of the
+ * different liquid egg variants. The actual item implementation has not
+ * been modernised yet, but the registry is required so that chicken data
+ * and future fluid logic can resolve identifiers.
+ */
+public final class LiquidEggRegistry {
+    private static final Map<Integer, LiquidEggRegistryItem> ITEMS = new HashMap<>();
+
+    private LiquidEggRegistry() {
+    }
+
+    public static void register(LiquidEggRegistryItem liquidEgg) {
+        ITEMS.put(liquidEgg.getId(), liquidEgg);
+    }
+
+    public static Collection<LiquidEggRegistryItem> getAll() {
+        return ITEMS.values();
+    }
+
+    public static LiquidEggRegistryItem findById(int id) {
+        return ITEMS.get(id);
+    }
+}

--- a/src/main/java/com/setycz/chickens/LiquidEggRegistryItem.java
+++ b/src/main/java/com/setycz/chickens/LiquidEggRegistryItem.java
@@ -1,0 +1,39 @@
+package com.setycz.chickens;
+
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.material.Fluid;
+
+/**
+ * Data record describing a single liquid egg entry. The modern fluid API is
+ * driven by {@link Fluid}, so we capture both the block that should be placed
+ * in the world and the associated fluid for future container logic.
+ */
+public final class LiquidEggRegistryItem {
+    private final int id;
+    private final Block liquid;
+    private final int eggColor;
+    private final Fluid fluid;
+
+    public LiquidEggRegistryItem(int id, Block liquid, int eggColor, Fluid fluid) {
+        this.id = id;
+        this.liquid = liquid;
+        this.eggColor = eggColor;
+        this.fluid = fluid;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public Block getLiquid() {
+        return liquid;
+    }
+
+    public int getEggColor() {
+        return eggColor;
+    }
+
+    public Fluid getFluid() {
+        return fluid;
+    }
+}

--- a/src/main/java/com/setycz/chickens/SpawnType.java
+++ b/src/main/java/com/setycz/chickens/SpawnType.java
@@ -1,0 +1,21 @@
+package com.setycz.chickens;
+
+/**
+ * Enumerates the biomes in which a chicken can spawn. Direct port from
+ * the classic mod, retained for compatibility with the registry layout.
+ */
+public enum SpawnType {
+    NORMAL,
+    SNOW,
+    NONE,
+    HELL;
+
+    public static String[] names() {
+        SpawnType[] states = values();
+        String[] names = new String[states.length];
+        for (int i = 0; i < states.length; i++) {
+            names[i] = states[i].name();
+        }
+        return names;
+    }
+}

--- a/src/main/java/com/setycz/chickens/config/ChickensConfigHolder.java
+++ b/src/main/java/com/setycz/chickens/config/ChickensConfigHolder.java
@@ -1,0 +1,22 @@
+package com.setycz.chickens.config;
+
+/**
+ * Thread-safe container for the currently active configuration snapshot.
+ * NeoForge loads configuration data on the mod loading thread, so a simple
+ * volatile reference is more than enough to safely publish values to any
+ * gameplay systems that might query them later on.
+ */
+public final class ChickensConfigHolder {
+    private static volatile ChickensConfigValues values = new ChickensConfigValues(10, 3, 5, 1.0f, false);
+
+    private ChickensConfigHolder() {
+    }
+
+    public static ChickensConfigValues get() {
+        return values;
+    }
+
+    public static void set(ChickensConfigValues newValues) {
+        values = newValues;
+    }
+}

--- a/src/main/java/com/setycz/chickens/config/ChickensConfigValues.java
+++ b/src/main/java/com/setycz/chickens/config/ChickensConfigValues.java
@@ -1,0 +1,45 @@
+package com.setycz.chickens.config;
+
+/**
+ * Immutable snapshot of the global configuration options that used to live
+ * in the legacy configuration file. Only a tiny subset of the mod reads
+ * these values right now, but keeping the structure mirrors the original
+ * behaviour and lets future ports reference the numbers without touching
+ * disk parsing logic again.
+ */
+public final class ChickensConfigValues {
+    private final int spawnProbability;
+    private final int minBroodSize;
+    private final int maxBroodSize;
+    private final float netherSpawnChanceMultiplier;
+    private final boolean alwaysShowStats;
+
+    public ChickensConfigValues(int spawnProbability, int minBroodSize, int maxBroodSize,
+            float netherSpawnChanceMultiplier, boolean alwaysShowStats) {
+        this.spawnProbability = spawnProbability;
+        this.minBroodSize = minBroodSize;
+        this.maxBroodSize = maxBroodSize;
+        this.netherSpawnChanceMultiplier = netherSpawnChanceMultiplier;
+        this.alwaysShowStats = alwaysShowStats;
+    }
+
+    public int getSpawnProbability() {
+        return spawnProbability;
+    }
+
+    public int getMinBroodSize() {
+        return minBroodSize;
+    }
+
+    public int getMaxBroodSize() {
+        return maxBroodSize;
+    }
+
+    public float getNetherSpawnChanceMultiplier() {
+        return netherSpawnChanceMultiplier;
+    }
+
+    public boolean isAlwaysShowStats() {
+        return alwaysShowStats;
+    }
+}

--- a/src/main/java/com/setycz/chickens/data/ChickensDataLoader.java
+++ b/src/main/java/com/setycz/chickens/data/ChickensDataLoader.java
@@ -1,0 +1,250 @@
+package com.setycz.chickens.data;
+
+import com.setycz.chickens.ChickensRegistry;
+import com.setycz.chickens.ChickensRegistryItem;
+import com.setycz.chickens.LiquidEggRegistry;
+import com.setycz.chickens.LiquidEggRegistryItem;
+import com.setycz.chickens.SpawnType;
+import com.setycz.chickens.config.ChickensConfigHolder;
+import com.setycz.chickens.config.ChickensConfigValues;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.material.Fluids;
+import net.neoforged.fml.loading.FMLPaths;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+
+/**
+ * Handles the legacy configuration file that drives chicken definitions.
+ * The original release stored everything in a Forge {@code .cfg}; here we
+ * emulate that behaviour with a simple {@link Properties} file so that we
+ * can preserve the mod's customisation surface without waiting for the GUI
+ * tooling to be ported.
+ */
+public final class ChickensDataLoader {
+    private static final Logger LOGGER = LoggerFactory.getLogger("ChickensData");
+    private static final String CONFIG_FILE = "chickens.properties";
+
+    private ChickensDataLoader() {
+    }
+
+    public static void bootstrap() {
+        registerLiquidEggs();
+        List<ChickensRegistryItem> defaults = DefaultChickens.create();
+        Path configFile = FMLPaths.CONFIGDIR.get().resolve(CONFIG_FILE);
+        ChickensConfigValues values = applyConfiguration(configFile, defaults);
+        ChickensConfigHolder.set(values);
+        defaults.forEach(ChickensRegistry::register);
+
+        LOGGER.info("Loaded {} chickens ({} enabled, {} disabled)",
+                defaults.size(),
+                ChickensRegistry.getItems().size(),
+                ChickensRegistry.getDisabledItems().size());
+    }
+
+    private static void registerLiquidEggs() {
+        LiquidEggRegistry.register(new LiquidEggRegistryItem(0, Blocks.WATER, 0x0000ff, Fluids.WATER));
+        LiquidEggRegistry.register(new LiquidEggRegistryItem(1, Blocks.LAVA, 0xff0000, Fluids.LAVA));
+    }
+
+    private static ChickensConfigValues applyConfiguration(Path configFile, List<ChickensRegistryItem> chickens) {
+        Properties props = new Properties();
+        if (Files.exists(configFile)) {
+            try (Reader reader = Files.newBufferedReader(configFile)) {
+                props.load(reader);
+            } catch (IOException e) {
+                LOGGER.warn("Failed to read chickens configuration; using defaults", e);
+            }
+        }
+
+        ChickensConfigValues values = readGeneralSettings(props);
+        Map<String, ChickensRegistryItem> byName = new HashMap<>();
+        for (ChickensRegistryItem chicken : chickens) {
+            byName.put(chicken.getEntityName(), chicken);
+        }
+
+        Map<ChickensRegistryItem, ParentNames> parentOverrides = new HashMap<>();
+        for (ChickensRegistryItem chicken : chickens) {
+            String prefix = "chicken." + chicken.getEntityName() + ".";
+            boolean enabled = readBoolean(props, prefix + "enabled", chicken.isEnabled());
+            chicken.setEnabled(enabled);
+
+            float layCoefficient = readFloat(props, prefix + "layCoefficient", 1.0f);
+            chicken.setLayCoefficient(layCoefficient);
+
+            ItemStack defaultEgg = chicken.createLayItem();
+            ItemStack layItem = readItemStack(props, prefix + "eggItem", prefix + "eggCount", defaultEgg);
+            chicken.setLayItem(layItem);
+
+            ItemStack defaultDrop = chicken.createDropItem();
+            ItemStack dropItem = readItemStack(props, prefix + "dropItem", prefix + "dropCount", defaultDrop);
+            chicken.setDropItem(dropItem);
+
+            String parent1 = readString(props, prefix + "parent1", chicken.getParent1() != null ? chicken.getParent1().getEntityName() : "");
+            String parent2 = readString(props, prefix + "parent2", chicken.getParent2() != null ? chicken.getParent2().getEntityName() : "");
+            parentOverrides.put(chicken, new ParentNames(parent1, parent2));
+
+            String spawnTypeName = readString(props, prefix + "spawnType", chicken.getSpawnType().name());
+            SpawnType spawnType = parseSpawnType(spawnTypeName, chicken.getSpawnType());
+            chicken.setSpawnType(spawnType);
+        }
+
+        for (Map.Entry<ChickensRegistryItem, ParentNames> entry : parentOverrides.entrySet()) {
+            ChickensRegistryItem chicken = entry.getKey();
+            ParentNames parents = entry.getValue();
+            ChickensRegistryItem parent1 = resolveParent(byName, parents.parent1());
+            ChickensRegistryItem parent2 = resolveParent(byName, parents.parent2());
+            if (parent1 != null && parent2 != null) {
+                chicken.setParentsNew(parent1, parent2);
+            } else {
+                chicken.setNoParents();
+            }
+        }
+
+        try {
+            Files.createDirectories(configFile.getParent());
+            try (Writer writer = Files.newBufferedWriter(configFile)) {
+                props.store(writer, "Modern Chickens configuration");
+            }
+        } catch (IOException e) {
+            LOGGER.warn("Unable to write chickens configuration", e);
+        }
+
+        return values;
+    }
+
+    private static ChickensRegistryItem resolveParent(Map<String, ChickensRegistryItem> byName, String parentName) {
+        if (parentName == null || parentName.isEmpty()) {
+            return null;
+        }
+        ChickensRegistryItem parent = byName.get(parentName);
+        if (parent == null) {
+            LOGGER.warn("Unknown parent '{}' referenced in configuration", parentName);
+        }
+        return parent;
+    }
+
+    private static SpawnType parseSpawnType(String value, SpawnType fallback) {
+        try {
+            return SpawnType.valueOf(value);
+        } catch (IllegalArgumentException ex) {
+            LOGGER.warn("Invalid spawn type '{}' in configuration, using {}", value, fallback);
+            return fallback;
+        }
+    }
+
+    private static ItemStack readItemStack(Properties props, String itemKey, String countKey, ItemStack fallback) {
+        String defaultItemId = getItemId(fallback);
+        String itemId = readString(props, itemKey, defaultItemId);
+        int count = readInt(props, countKey, fallback.getCount());
+        ItemStack stack = decodeItemStack(itemId, count);
+        if (stack.isEmpty()) {
+            props.setProperty(itemKey, defaultItemId);
+            props.setProperty(countKey, Integer.toString(fallback.getCount()));
+            return fallback.copy();
+        }
+        return stack;
+    }
+
+    private static ItemStack decodeItemStack(String itemId, int count) {
+        if (itemId == null || itemId.isEmpty()) {
+            return ItemStack.EMPTY;
+        }
+        ResourceLocation id = ResourceLocation.tryParse(itemId);
+        if (id == null) {
+            LOGGER.warn("Malformed item identifier '{}' in configuration", itemId);
+            return ItemStack.EMPTY;
+        }
+        Item item = BuiltInRegistries.ITEM.get(id);
+        if (item == null) {
+            LOGGER.warn("Unknown item '{}' referenced in configuration", itemId);
+            return ItemStack.EMPTY;
+        }
+        return new ItemStack(item, Math.max(count, 1));
+    }
+
+    private static String getItemId(ItemStack stack) {
+        ResourceLocation key = BuiltInRegistries.ITEM.getKey(stack.getItem());
+        return key != null ? key.toString() : "minecraft:air";
+    }
+
+    private static ChickensConfigValues readGeneralSettings(Properties props) {
+        int spawnProbability = readInt(props, "general.spawnProbability", 10);
+        int minBroodSize = readInt(props, "general.minBroodSize", 3);
+        int maxBroodSize = readInt(props, "general.maxBroodSize", 5);
+        float multiplier = readFloat(props, "general.netherSpawnChanceMultiplier", 1.0f);
+        boolean alwaysShowStats = readBoolean(props, "general.alwaysShowStats", false);
+        return new ChickensConfigValues(spawnProbability, minBroodSize, maxBroodSize, multiplier, alwaysShowStats);
+    }
+
+    private static String readString(Properties props, String key, String defaultValue) {
+        String value = props.getProperty(key);
+        if (value == null) {
+            props.setProperty(key, defaultValue);
+            return defaultValue;
+        }
+        return value;
+    }
+
+    private static boolean readBoolean(Properties props, String key, boolean defaultValue) {
+        String value = props.getProperty(key);
+        if (value == null) {
+            props.setProperty(key, Boolean.toString(defaultValue));
+            return defaultValue;
+        }
+        if (value.equalsIgnoreCase("true") || value.equalsIgnoreCase("false")) {
+            return Boolean.parseBoolean(value);
+        }
+        props.setProperty(key, Boolean.toString(defaultValue));
+        return defaultValue;
+    }
+
+    private static int readInt(Properties props, String key, int defaultValue) {
+        String value = props.getProperty(key);
+        if (value == null) {
+            props.setProperty(key, Integer.toString(defaultValue));
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            props.setProperty(key, Integer.toString(defaultValue));
+            return defaultValue;
+        }
+    }
+
+    private static float readFloat(Properties props, String key, float defaultValue) {
+        String value = props.getProperty(key);
+        if (value == null) {
+            props.setProperty(key, Float.toString(defaultValue));
+            return defaultValue;
+        }
+        try {
+            return Float.parseFloat(value);
+        } catch (NumberFormatException e) {
+            props.setProperty(key, Float.toString(defaultValue));
+            return defaultValue;
+        }
+    }
+
+    private record ParentNames(String parent1, String parent2) {
+        ParentNames {
+            Objects.requireNonNull(parent1);
+            Objects.requireNonNull(parent2);
+        }
+    }
+}

--- a/src/main/java/com/setycz/chickens/data/DefaultChickens.java
+++ b/src/main/java/com/setycz/chickens/data/DefaultChickens.java
@@ -1,0 +1,300 @@
+package com.setycz.chickens.data;
+
+import com.setycz.chickens.ChickensMod;
+import com.setycz.chickens.ChickensRegistryItem;
+import com.setycz.chickens.SpawnType;
+import com.setycz.chickens.registry.ModRegistry;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.DyeColor;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.Blocks;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Recreates the legacy {@code generateDefaultChickens} method from the 1.10
+ * release. The data has been massaged to use modern item constants (for
+ * example, the generic log block has become the dedicated {@code oak_log})
+ * but the relationships and identifiers are otherwise identical.
+ */
+public final class DefaultChickens {
+    private DefaultChickens() {
+    }
+
+    public static List<ChickensRegistryItem> create() {
+        List<ChickensRegistryItem> chickens = new ArrayList<>();
+
+        chickens.add(new ChickensRegistryItem(
+                com.setycz.chickens.ChickensRegistry.SMART_CHICKEN_ID,
+                "SmartChicken",
+                texture("SmartChicken"),
+                new ItemStack(Items.EGG),
+                0xffffff, 0xffff00).setSpawnType(SpawnType.NONE));
+
+        ChickensRegistryItem whiteChicken = createDyeChicken(DyeColor.WHITE, "WhiteChicken")
+                .setDropItem(new ItemStack(Items.BONE)).setSpawnType(SpawnType.NORMAL);
+        chickens.add(whiteChicken);
+        ChickensRegistryItem yellowChicken = createDyeChicken(DyeColor.YELLOW, "YellowChicken");
+        chickens.add(yellowChicken);
+        ChickensRegistryItem blueChicken = createDyeChicken(DyeColor.BLUE, "BlueChicken");
+        chickens.add(blueChicken);
+        ChickensRegistryItem greenChicken = createDyeChicken(DyeColor.GREEN, "GreenChicken");
+        chickens.add(greenChicken);
+        ChickensRegistryItem redChicken = createDyeChicken(DyeColor.RED, "RedChicken");
+        chickens.add(redChicken);
+        ChickensRegistryItem blackChicken = createDyeChicken(DyeColor.BLACK, "BlackChicken");
+        chickens.add(blackChicken);
+
+        ChickensRegistryItem pinkChicken = createDyeChicken(DyeColor.PINK, "PinkChicken")
+                .setParentsNew(redChicken, whiteChicken);
+        chickens.add(pinkChicken);
+        ChickensRegistryItem purpleChicken = createDyeChicken(DyeColor.PURPLE, "PurpleChicken")
+                .setParentsNew(blueChicken, redChicken);
+        chickens.add(purpleChicken);
+        chickens.add(createDyeChicken(DyeColor.ORANGE, "OrangeChicken")
+                .setParentsNew(redChicken, yellowChicken));
+        chickens.add(createDyeChicken(DyeColor.LIGHT_BLUE, "LightBlueChicken")
+                .setParentsNew(whiteChicken, blueChicken));
+        chickens.add(createDyeChicken(DyeColor.LIME, "LimeChicken")
+                .setParentsNew(greenChicken, whiteChicken));
+        ChickensRegistryItem grayChicken = createDyeChicken(DyeColor.GRAY, "GrayChicken")
+                .setParentsNew(blackChicken, whiteChicken);
+        chickens.add(grayChicken);
+        chickens.add(createDyeChicken(DyeColor.CYAN, "CyanChicken")
+                .setParentsNew(blueChicken, greenChicken));
+
+        chickens.add(createDyeChicken(DyeColor.LIGHT_GRAY, "SilverDyeChicken")
+                .setParentsNew(grayChicken, whiteChicken));
+        chickens.add(createDyeChicken(DyeColor.MAGENTA, "MagentaChicken")
+                .setParentsNew(purpleChicken, pinkChicken));
+
+        ChickensRegistryItem flintChicken = new ChickensRegistryItem(
+                101, "FlintChicken", texture("FlintChicken"),
+                new ItemStack(Items.FLINT),
+                0x6b6b47, 0xa3a375);
+        chickens.add(flintChicken);
+
+        ChickensRegistryItem quartzChicken = new ChickensRegistryItem(
+                104, "QuartzChicken", texture("QuartzChicken"),
+                new ItemStack(Items.QUARTZ),
+                0x4d0000, 0x1a0000).setSpawnType(SpawnType.HELL);
+        chickens.add(quartzChicken);
+
+        ChickensRegistryItem logChicken = new ChickensRegistryItem(
+                108, "LogChicken", texture("LogChicken"),
+                new ItemStack(Blocks.OAK_LOG),
+                0x98846d, 0x528358);
+        chickens.add(logChicken);
+
+        ChickensRegistryItem sandChicken = new ChickensRegistryItem(
+                105, "SandChicken", texture("SandChicken"),
+                new ItemStack(Blocks.SAND),
+                0xece5b1, 0xa7a06c);
+        chickens.add(sandChicken);
+
+        ChickensRegistryItem stringChicken = new ChickensRegistryItem(
+                303, "StringChicken", texture("StringChicken"),
+                new ItemStack(Items.STRING),
+                0x331a00, 0x800000,
+                blackChicken, logChicken
+        ).setDropItem(new ItemStack(Items.SPIDER_EYE));
+        chickens.add(stringChicken);
+
+        ChickensRegistryItem glowstoneChicken = new ChickensRegistryItem(
+                202, "GlowstoneChicken", texture("GlowstoneChicken"),
+                new ItemStack(Items.GLOWSTONE_DUST),
+                0xffff66, 0xffff00,
+                quartzChicken, yellowChicken);
+        chickens.add(glowstoneChicken);
+
+        ChickensRegistryItem gunpowderChicken = new ChickensRegistryItem(
+                100, "GunpowderChicken", texture("GunpowderChicken"),
+                new ItemStack(Items.GUNPOWDER),
+                0x999999, 0x404040,
+                sandChicken, flintChicken);
+        chickens.add(gunpowderChicken);
+
+        ChickensRegistryItem redstoneChicken = new ChickensRegistryItem(
+                201, "RedstoneChicken", texture("RedstoneChicken"),
+                new ItemStack(Items.REDSTONE),
+                0xe60000, 0x800000,
+                redChicken,
+                sandChicken);
+        chickens.add(redstoneChicken);
+
+        ChickensRegistryItem glassChicken = new ChickensRegistryItem(
+                106, "GlassChicken", texture("GlassChicken"),
+                new ItemStack(Blocks.GLASS),
+                0xffffff, 0xeeeeff,
+                quartzChicken, redstoneChicken);
+        chickens.add(glassChicken);
+
+        ChickensRegistryItem ironChicken = new ChickensRegistryItem(
+                203, "IronChicken", texture("IronChicken"),
+                new ItemStack(Items.IRON_INGOT),
+                0xffffcc, 0xffcccc,
+                flintChicken, whiteChicken);
+        chickens.add(ironChicken);
+
+        ChickensRegistryItem coalChicken = new ChickensRegistryItem(
+                204, "CoalChicken", texture("CoalChicken"),
+                new ItemStack(Items.COAL),
+                0x262626, 0x000000,
+                flintChicken, logChicken);
+        chickens.add(coalChicken);
+
+        ChickensRegistryItem brownChicken = createDyeChicken(DyeColor.BROWN, "BrownChicken")
+                .setParentsNew(redChicken, greenChicken);
+        chickens.add(brownChicken);
+
+        ChickensRegistryItem goldChicken = new ChickensRegistryItem(
+                300, "GoldChicken", texture("GoldChicken"),
+                new ItemStack(Items.GOLD_NUGGET),
+                0xcccc00, 0xffff80,
+                ironChicken, yellowChicken);
+        chickens.add(goldChicken);
+
+        ChickensRegistryItem snowballChicken = new ChickensRegistryItem(
+                102, "SnowballChicken", texture("SnowballChicken"),
+                new ItemStack(Items.SNOWBALL),
+                0x33bbff, 0x0088cc,
+                blueChicken, logChicken).setSpawnType(SpawnType.SNOW);
+        chickens.add(snowballChicken);
+
+        ChickensRegistryItem waterChicken = new ChickensRegistryItem(
+                206, "WaterChicken", texture("WaterChicken"),
+                // The liquid egg item still behaves as a stub so no metadata
+                // is attached yet; subtype support will arrive with the item
+                // rewrite.
+                new ItemStack(ModRegistry.LIQUID_EGG.get()),
+                0x000099, 0x8080ff,
+                gunpowderChicken, snowballChicken);
+        chickens.add(waterChicken);
+
+        ChickensRegistryItem lavaChicken = new ChickensRegistryItem(
+                103, "LavaChicken", texture("LavaChicken"),
+                // As above, metadata free placeholder until subtype logic lands.
+                new ItemStack(ModRegistry.LIQUID_EGG.get()),
+                0xcc3300, 0xffff00,
+                coalChicken, quartzChicken).setSpawnType(SpawnType.HELL);
+        chickens.add(lavaChicken);
+
+        ChickensRegistryItem clayChicken = new ChickensRegistryItem(
+                200, "ClayChicken", texture("ClayChicken"),
+                new ItemStack(Items.CLAY_BALL),
+                0xcccccc, 0xbfbfbf,
+                snowballChicken, sandChicken);
+        chickens.add(clayChicken);
+
+        ChickensRegistryItem leatherChicken = new ChickensRegistryItem(
+                107, "LeatherChicken", texture("LeatherChicken"),
+                new ItemStack(Items.LEATHER),
+                0xA7A06C, 0x919191,
+                stringChicken, brownChicken);
+        chickens.add(leatherChicken);
+
+        ChickensRegistryItem netherwartChicken = new ChickensRegistryItem(
+                207, "NetherwartChicken", texture("NetherwartChicken"),
+                new ItemStack(Items.NETHER_WART),
+                0x800000, 0x331a00,
+                brownChicken, glowstoneChicken);
+        chickens.add(netherwartChicken);
+
+        ChickensRegistryItem diamondChicken = new ChickensRegistryItem(
+                301, "DiamondChicken", texture("DiamondChicken"),
+                new ItemStack(Items.DIAMOND),
+                0x99ccff, 0xe6f2ff,
+                glassChicken, goldChicken);
+        chickens.add(diamondChicken);
+
+        ChickensRegistryItem blazeChicken = new ChickensRegistryItem(
+                302, "BlazeChicken", texture("BlazeChicken"),
+                new ItemStack(Items.BLAZE_ROD),
+                0xffff66, 0xff3300,
+                goldChicken, lavaChicken);
+        chickens.add(blazeChicken);
+
+        ChickensRegistryItem slimeChicken = new ChickensRegistryItem(
+                205, "SlimeChicken", texture("SlimeChicken"),
+                new ItemStack(Items.SLIME_BALL),
+                0x009933, 0x99ffbb,
+                clayChicken, greenChicken);
+        chickens.add(slimeChicken);
+
+        ChickensRegistryItem enderChicken = new ChickensRegistryItem(
+                401, "EnderChicken", texture("EnderChicken"),
+                new ItemStack(Items.ENDER_PEARL),
+                0x001a00, 0x001a33,
+                diamondChicken, netherwartChicken);
+        chickens.add(enderChicken);
+
+        ChickensRegistryItem ghastChicken = new ChickensRegistryItem(
+                402, "GhastChicken", texture("GhastChicken"),
+                new ItemStack(Items.GHAST_TEAR),
+                0xffffcc, 0xffffff,
+                whiteChicken, blazeChicken);
+        chickens.add(ghastChicken);
+
+        ChickensRegistryItem emeraldChicken = new ChickensRegistryItem(
+                400, "EmeraldChicken", texture("EmeraldChicken"),
+                new ItemStack(Items.EMERALD),
+                0x00cc00, 0x003300,
+                diamondChicken, greenChicken);
+        chickens.add(emeraldChicken);
+
+        ChickensRegistryItem magmaChicken = new ChickensRegistryItem(
+                403, "MagmaChicken", texture("MagmaChicken"),
+                new ItemStack(Items.MAGMA_CREAM),
+                0x1a0500, 0x000000,
+                slimeChicken, blazeChicken);
+        chickens.add(magmaChicken);
+
+        return chickens;
+    }
+
+    private static ChickensRegistryItem createDyeChicken(DyeColor color, String name) {
+        return new ChickensRegistryItem(
+                color.getId(),
+                name,
+                texture(name),
+                new ItemStack(DyeColorUtils.itemFor(color)),
+                0xf2f2f2, color.getTextColor());
+    }
+
+    private static ResourceLocation texture(String name) {
+        return ResourceLocation.fromNamespaceAndPath(ChickensMod.MOD_ID, "textures/entity/" + name + ".png");
+    }
+
+    /**
+     * Minor helper that converts modern dye colours back into their item
+     * representations. Pulling this out keeps {@link #createDyeChicken}
+     * readable even with the metadata removal that happened after 1.12.
+     */
+    private static final class DyeColorUtils {
+        private DyeColorUtils() {
+        }
+
+        private static net.minecraft.world.item.Item itemFor(DyeColor color) {
+            return switch (color) {
+                case WHITE -> Items.WHITE_DYE;
+                case ORANGE -> Items.ORANGE_DYE;
+                case MAGENTA -> Items.MAGENTA_DYE;
+                case LIGHT_BLUE -> Items.LIGHT_BLUE_DYE;
+                case YELLOW -> Items.YELLOW_DYE;
+                case LIME -> Items.LIME_DYE;
+                case PINK -> Items.PINK_DYE;
+                case GRAY -> Items.GRAY_DYE;
+                case LIGHT_GRAY -> Items.LIGHT_GRAY_DYE;
+                case CYAN -> Items.CYAN_DYE;
+                case PURPLE -> Items.PURPLE_DYE;
+                case BLUE -> Items.BLUE_DYE;
+                case BROWN -> Items.BROWN_DYE;
+                case GREEN -> Items.GREEN_DYE;
+                case RED -> Items.RED_DYE;
+                case BLACK -> Items.BLACK_DYE;
+            };
+        }
+    }
+}

--- a/src/main/java/com/setycz/chickens/registry/ModRegistry.java
+++ b/src/main/java/com/setycz/chickens/registry/ModRegistry.java
@@ -1,0 +1,40 @@
+package com.setycz.chickens.registry;
+
+import com.setycz.chickens.ChickensMod;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.neoforged.neoforge.registries.DeferredItem;
+import net.neoforged.neoforge.registries.DeferredRegister;
+import net.neoforged.neoforge.registries.DeferredRegister.Blocks;
+import net.neoforged.neoforge.registries.DeferredRegister.Items;
+import net.neoforged.bus.api.IEventBus;
+
+/**
+ * Centralised registry bootstrap. The majority of the mod's content will
+ * register through these deferred registers to ensure data is ready
+ * before the game begins loading worlds.
+ */
+public final class ModRegistry {
+    public static final Items ITEMS = DeferredRegister.createItems(ChickensMod.MOD_ID);
+    public static final Blocks BLOCKS = DeferredRegister.createBlocks(ChickensMod.MOD_ID);
+
+    private ModRegistry() {
+    }
+
+    public static void init(IEventBus modBus) {
+        ITEMS.register(modBus);
+        BLOCKS.register(modBus);
+    }
+
+    // These registrations are still simple placeholders; dedicated item
+    // classes will follow once their behaviour has been ported from the
+    // original mod.
+    public static final DeferredItem<Item> SPAWN_EGG = ITEMS.register("spawn_egg",
+            () -> new Item(new Item.Properties().stacksTo(16)));
+    public static final DeferredItem<Item> COLORED_EGG = ITEMS.register("colored_egg",
+            () -> new Item(new Item.Properties().stacksTo(16)));
+    public static final DeferredItem<Item> LIQUID_EGG = ITEMS.register("liquid_egg",
+            () -> new Item(new Item.Properties().stacksTo(16)));
+    public static final DeferredItem<Item> ANALYZER = ITEMS.register("analyzer",
+            () -> new Item(new Item.Properties().stacksTo(1)));
+}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,0 +1,23 @@
+modLoader="javafml"
+loaderVersion="[4,)"
+license="MIT"
+issueTrackerURL="https://example.com"
+showAsResourcePack=true
+[[mods]]
+modId="chickens"
+version="1.0.0"
+displayName="Modern Chickens"
+description='''
+Modernized port of the classic Chickens mod for Minecraft 1.21.1.'''
+[[dependencies.chickens]]
+modId="neoforge"
+mandatory=true
+versionRange="[21.1.0,)"
+ordering="NONE"
+sides="BOTH"
+[[dependencies.chickens]]
+modId="minecraft"
+mandatory=true
+versionRange="[1.21.1,1.22)"
+ordering="NONE"
+sides="BOTH"

--- a/src/main/resources/assets/chickens/lang/en_us.json
+++ b/src/main/resources/assets/chickens/lang/en_us.json
@@ -1,0 +1,3 @@
+{
+  "item.chickens.debug_feather": "Debug Feather"
+}

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 34,
+    "description": "Modern Chickens resources"
+  }
+}


### PR DESCRIPTION
## Summary
- load the legacy chicken definitions through a new data loader that mirrors the original configuration options
- bring the liquid egg registry and placeholder mod items across so dependent systems have the required identifiers
- invoke the bootstrap during common setup to populate the registry data at runtime

## Testing
- gradle --no-daemon --console=plain build

------
https://chatgpt.com/codex/tasks/task_e_68f1cd025348832fa8c650da5277e184